### PR TITLE
FIX: Fix Path to access secret

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,6 +64,6 @@ steps:
 
 secrets:
 - secretEnv:
-    BREW_WING_SECRET: projects/903635083978/secrets/brew-wing-secret/versions/latest
+    BREW_WING_SECRET: projects/$PROJECT_ID/secrets/brew-wing-secret/versions/latest
 
 timeout: 1200s 


### PR DESCRIPTION
I checked and modified that the project ID is written to the path through the built-in function