### PR TITLE
FIX: Add backend url in allowed hosts

### DIFF
--- a/brewing/brewing/settings.py
+++ b/brewing/brewing/settings.py
@@ -22,7 +22,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 
-ALLOWED_HOSTS = ['brewwing-frontend-903635083978.us-central1.run.app']
+ALLOWED_HOSTS = [
+    'brewwing-frontend-903635083978.us-central1.run.app',
+    'brewwing-backend-903635083978.us-central1.run.app'
+    ]
 
 
 # Application definition


### PR DESCRIPTION
Add backend url in allowed hosts to solve the problem that django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header error